### PR TITLE
Upgrade to latest commons-beanutils.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.7.0</version>
+      <version>1.9.4</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/src/java/org/apache/commons/jelly/impl/TagScript.java
+++ b/src/java/org/apache/commons/jelly/impl/TagScript.java
@@ -25,11 +25,13 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.ConvertingWrapDynaBean;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.DynaBean;
 import org.apache.commons.beanutils.DynaProperty;
 
+import org.apache.commons.beanutils.SuppressPropertiesBeanIntrospector;
 import org.apache.commons.jelly.CompilableTag;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
@@ -205,6 +207,7 @@ public class TagScript implements Script {
 
     /** Evaluates the body of a tag */
     public void run(JellyContext context, XMLOutput output) throws JellyTagException {
+        BeanUtilsBean.getInstance().getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
         URL rootURL = context.getRootURL();
         URL currentURL = context.getCurrentURL();
         final Object oldParent=context.getVariables().get(PARENT_TAG);


### PR DESCRIPTION
Pick up the latest improvements and hardenings.

If we ever update this and release a new version it would be good to update this dependency. I haven't found any urgency for it, though. Jenkins appears to package the version referenced in jenkins/core. Maybe the one referenced in stapler. Probably not this one.

Other dependencies should probably also be updated, but I don't currently have any additional information on others.