### PR TITLE
Remove redundant `project.build.sourceEncoding` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,6 @@
     <revision>1.1-jenkins-20220631</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/jelly</gitHubRepo>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spotbugs.skip>true</spotbugs.skip>
   </properties>
 


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.