### PR TITLE
Update JUnit to 5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.ipr
 *.iws
 target
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
         <version>2.0.0</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.9.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ant</groupId>


### PR DESCRIPTION
Updates JUnit to 5.x in favor of the EOL line 4.x. Local testing produced worked well, nor is the build process impacted by deprecations from 4 -> 5.