### PR TITLE
Deprecate jelly:core "expr" tag in favor of "out"

### DIFF
--- a/core/src/main/java/org/apache/commons/jelly/tags/core/CoreTagLibrary.java
+++ b/core/src/main/java/org/apache/commons/jelly/tags/core/CoreTagLibrary.java
@@ -45,7 +45,7 @@ public class CoreTagLibrary extends TagLibrary {
         registerTag("jelly", JellyTag.class);
 
         // core tags
-        registerTag("out", ExprTag.class);
+        registerTag("out", OutTag.class);
         registerTag("catch", CatchTag.class);
         registerTag("forEach", ForEachTag.class);
         registerTag("set", SetTag.class);

--- a/core/src/main/java/org/apache/commons/jelly/tags/core/OutTag.java
+++ b/core/src/main/java/org/apache/commons/jelly/tags/core/OutTag.java
@@ -21,24 +21,17 @@ import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.jelly.expression.Expression;
 import org.xml.sax.SAXException;
 
-/** A tag which evaluates an expression
-  *
-  * tag expr
-  * @author <a href="mailto:jstrachan@apache.org">James Strachan</a>
-  * @version $Revision: 155420 $
-  * @deprecated In Jenkins, we use the {@link org.apache.commons.jelly.tags.core.OutTag}.
-  */
-@Deprecated
-public class ExprTag extends TagSupport {
+/**
+ * Cancels the effect of &lt;?jelly escape-by-default='true'?&gt; and allow expressions to produce mark up.
+ */
+public class OutTag extends TagSupport {
 
     /** The expression to evaluate. */
     private Expression value;
 
-    public ExprTag() {
+    public OutTag() {
     }
 
-    // Tag interface
-    //-------------------------------------------------------------------------
     public void doTag(XMLOutput output) throws JellyTagException {
         if (value != null) {
             String text = value.evaluateAsString(context);
@@ -54,11 +47,8 @@ public class ExprTag extends TagSupport {
         }
     }
 
-    // Properties
-    //-------------------------------------------------------------------------
-
     /**
-     * Sets the Jexl expression to evaluate.
+     * The value that should be escaped.
      *
      * @param value required
      */


### PR DESCRIPTION
In Jenkins, we rather use the "out" tag, over "expr". I would like to propose to deprecate the "expr" tag in favor of the now properly created and registered "out" tag. The description is taken from https://wiki.jenkins.io/display/JENKINS/Jelly+and+XSS+prevention

The "out" tag was registered with the [same class ](https://github.com/jenkinsci/jelly/blob/21bb8e2ef474897ccaf5526c3107d8ee4043a4c9/core/src/main/java/org/apache/commons/jelly/tags/core/CoreTagLibrary.java#L48) the "expr" tag was. Hence, both have been a drop in for each other.

