### PR TITLE
Build and publish tag library reference documentation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":semanticCommitsDisabled"
+  ],
+  "enabledManagers": ["regex"],
+  "regexManagers": [
+    {
+      "fileMatch": ["src/site/site.xml"],
+      "matchStrings": ["<version>(?<currentValue>.*?)<\/version>"],
+      "depNameTemplate": "org.apache.maven.skins:maven-fluido-skin",
+      "datasourceTemplate": "maven"
+    }
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "rebaseWhen": "conflicted",
+  "schedule": ["on the first day of the month"]
+}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,54 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+permissions:
+  contents: read
+  pages: write      # to deploy to Pages
+  id-token: write   # to verify the deployment originates from an appropriate source
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build site
+        run: |
+          mkdir /tmp/site
+          mvn -B -V -e -ntp -Pquick-build clean verify site site:stage -DstagingDirectory=/tmp/site
+    - run:
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: /tmp/site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           mkdir /tmp/site
           mvn -B -V -e -ntp -Pquick-build clean verify site site:stage -DstagingDirectory=/tmp/site
-    - run:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,13 @@
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
+  <distributionManagement>
+    <site>
+      <id>default-site</id>
+      <url>http://jenkinsci.github.io/jelly/</url>
+    </site>
+  </distributionManagement>
+
   <properties>
     <revision>1.1-jenkins-20230125</revision>
     <changelist>-SNAPSHOT</changelist>
@@ -111,4 +118,15 @@
       </plugin>
     </plugins>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>io.jenkins.tools.maven</groupId>
+        <artifactId>jellydoc-maven-plugin</artifactId>
+        <!-- TODO manage in parent POM -->
+        <version>137.v803fea_a_fb_c75</version>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -9,7 +9,7 @@
   <body>
     <menu name="Overview">
       <item name="Introduction" href="index.html"/>
-      <item name="Tag Reference" href="plugin-info.html">
+      <item name="Tag Reference">
         <item name="Core" href="commons-jelly/jelly-taglib-ref.html"/>
         <item name="Ant" href="commons-jelly-tags/commons-jelly-tags-ant/jelly-taglib-ref.html"/>
         <item name="Define" href="commons-jelly-tags/commons-jelly-tags-define/jelly-taglib-ref.html"/>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="Jelly">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.12.0</version>
+  </skin>
+
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="Tag Reference" href="plugin-info.html">
+        <item name="Core" href="commons-jelly/jelly-taglib-ref.html"/>
+        <item name="Ant" href="commons-jelly-tags/commons-jelly-tags-ant/jelly-taglib-ref.html"/>
+        <item name="Define" href="commons-jelly-tags/commons-jelly-tags-define/jelly-taglib-ref.html"/>
+        <item name="DynaBean" href="commons-jelly-tags/commons-jelly-tags-dynabean/jelly-taglib-ref.html"/>
+        <item name="Format" href="commons-jelly-tags/commons-jelly-tags-fmt/jelly-taglib-ref.html"/>
+        <item name="JUnit" href="commons-jelly-tags/commons-jelly-tags-junit/jelly-taglib-ref.html"/>
+        <item name="Log" href="commons-jelly-tags/commons-jelly-tags-log/jelly-taglib-ref.html"/>
+        <item name="Utility" href="commons-jelly-tags/commons-jelly-tags-util/jelly-taglib-ref.html"/>
+        <item name="XML" href="commons-jelly-tags/commons-jelly-tags-xml/jelly-taglib-ref.html"/>
+      </item>
+    </menu>
+    <menu ref="reports" inherit="bottom"/>
+  </body>
+
+  <custom>
+    <fluidoSkin>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>jenkinsci/jelly</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>orange</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>


### PR DESCRIPTION
Eat our own dogfood by running `jellydoc-maven-plugin` to generate the Jellydocs for this repository and publish them to GitHub Pages.