### PR TITLE
[JENKINS-73256] Migrate Jelly from EE 8 to EE 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,7 @@ updates:
     ignore:
       # Provided by the Web container, so aligned with Jetty.
       - dependency-name: "jakarta.servlet:jakarta.servlet-api"
-      # Contains incompatible API changes and needs compatibility work.
       - dependency-name: "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api"
-        versions: [">=2.0.0"]
       # Ignore 1.2.0-atlassian-2
       - dependency-name: "jaxen:jaxen"
   - package-ecosystem: "github-actions"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,14 +49,14 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>4.0.4</version>
-      <optional>true</optional>
+      <version>5.0.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-      <version>1.2.7</version>
-      <optional>true</optional>
+      <version>2.0.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>

--- a/core/src/main/java/org/apache/commons/jelly/servlet/JellyServlet.java
+++ b/core/src/main/java/org/apache/commons/jelly/servlet/JellyServlet.java
@@ -23,11 +23,11 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;

--- a/core/src/main/java/org/apache/commons/jelly/servlet/JellyServletContext.java
+++ b/core/src/main/java/org/apache/commons/jelly/servlet/JellyServletContext.java
@@ -18,7 +18,7 @@ package org.apache.commons.jelly.servlet;
 
 import org.apache.commons.jelly.JellyContext;
 
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/core/src/main/java/org/apache/commons/jelly/tags/core/ForEachTag.java
+++ b/core/src/main/java/org/apache/commons/jelly/tags/core/ForEachTag.java
@@ -18,7 +18,7 @@ package org.apache.commons.jelly.tags.core;
 
 import java.util.Iterator;
 
-import javax.servlet.jsp.jstl.core.LoopTagStatus;
+import jakarta.servlet.jsp.jstl.core.LoopTagStatus;
 
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.MissingAttributeException;

--- a/core/src/main/resources/org/apache/commons/jelly/tags/Resources.properties
+++ b/core/src/main/resources/org/apache/commons/jelly/tags/Resources.properties
@@ -228,10 +228,10 @@ SQL_DATASOURCE_NULL=\
     'dataSource' is null
 
 SQL_MAXROWS_PARSE_ERROR=\
-    Error parsing 'javax.servlet.jsp.jstl.sql.maxRows' configuration setting: "{0}"
+    Error parsing 'jakarta.servlet.jsp.jstl.sql.maxRows' configuration setting: "{0}"
 
 SQL_MAXROWS_INVALID=\
-    'javax.servlet.jsp.jstl.sql.maxRows' configuration setting neither an Integer nor a String
+    'jakarta.servlet.jsp.jstl.sql.maxRows' configuration setting neither an Integer nor a String
 
 SQL_DATE_PARAM_INVALID_TYPE=\
     In &lt;dateParam&gt;, invalid 'type' attribute: "{0}"

--- a/jelly-tags/fmt/src/main/java/org/apache/commons/jelly/tags/fmt/TimeZoneTag.java
+++ b/jelly-tags/fmt/src/main/java/org/apache/commons/jelly/tags/fmt/TimeZoneTag.java
@@ -94,7 +94,7 @@ public class TimeZoneTag extends TagSupport {
      * the time zone is taken from the enclosing &lt;timeZone&gt; action.
      *
      * <p> Otherwise, the time zone configuration setting
-     * <tt>javax.servlet.jsp.jstl.core.Config.FMT_TIME_ZONE</tt>
+     * <tt>jakarta.servlet.jsp.jstl.core.Config.FMT_TIME_ZONE</tt>
      * is used.
      *
      * @param jc the page containing the action for which the


### PR DESCRIPTION
### Context

Goes with three other pull requests:

- https://github.com/jenkinsci/stapler/pull/482
- https://github.com/jenkinsci/jenkins/pull/9672
- https://github.com/jenkinsci/winstone/pull/396

### Description

Replace dependencies with EE 9 versions in `pom.xml` and update all relevant imports.

### Testing done

Full PCT/ATH