### PR TITLE
[JENKINS-73774] Stop overriding `#printStackTrace` and `#getCause` in `JellyException`

### DIFF
--- a/core/src/main/java/org/apache/commons/jelly/JellyException.java
+++ b/core/src/main/java/org/apache/commons/jelly/JellyException.java
@@ -28,9 +28,6 @@ import java.io.PrintWriter;
 
 public class JellyException extends Exception implements LocationAware {
 
-    /** the underlying cause of the exception */
-    private Throwable cause;
-
     /** the Jelly file which caused the problem */
     private String fileName;
 
@@ -51,13 +48,11 @@ public class JellyException extends Exception implements LocationAware {
     }
 
     public JellyException(String message, Throwable cause) {
-        super(message);
-        this.cause = cause;
+        super(message, cause);
     }
 
     public JellyException(Throwable cause) {
-        super(cause.getLocalizedMessage());
-        this.cause = cause;
+        super(cause);
     }
 
     public JellyException(Throwable cause, String fileName, String elementName, int columnNumber, int lineNumber) {
@@ -65,8 +60,7 @@ public class JellyException extends Exception implements LocationAware {
     }
 
     public JellyException(String reason, Throwable cause, String fileName, String elementName, int columnNumber, int lineNumber) {
-        super( (reason==null?cause.getClass().getName():reason) );
-        this.cause = cause;
+        super( (reason==null?cause.getClass().getName():reason), cause);
         this.fileName = fileName;
         this.elementName = elementName;
         this.columnNumber = columnNumber;
@@ -80,11 +74,6 @@ public class JellyException extends Exception implements LocationAware {
         this.columnNumber = columnNumber;
         this.lineNumber = lineNumber;
     }
-
-    public Throwable getCause() {
-        return cause;
-    }
-
 
     /**
      * @return the line number of the tag 
@@ -160,9 +149,9 @@ public class JellyException extends Exception implements LocationAware {
     public void printStackTrace(PrintWriter s) {
         synchronized (s) {
             super.printStackTrace(s);
-            if  (cause != null && !isChainingSupported()) {
+            if  (getCause() != null && !isChainingSupported()) {
                 s.println("Root cause");
-                cause.printStackTrace(s);
+                getCause().printStackTrace(s);
             }
         }
     }
@@ -170,18 +159,18 @@ public class JellyException extends Exception implements LocationAware {
     public void printStackTrace(PrintStream s) {
         synchronized (s) {
             super.printStackTrace(s);
-            if  (cause != null && !isChainingSupported()) {
+            if  (getCause() != null && !isChainingSupported()) {
                 s.println("Root cause");
-                cause.printStackTrace(s);
+                getCause().printStackTrace(s);
             }
         }
     }
 
     public void printStackTrace() {
         super.printStackTrace();
-        if (cause != null && !isChainingSupported()) {
+        if (getCause() != null && !isChainingSupported()) {
             System.out.println("Root cause");
-            cause.printStackTrace();
+            getCause().printStackTrace();
         }
     }
 

--- a/core/src/main/java/org/apache/commons/jelly/JellyException.java
+++ b/core/src/main/java/org/apache/commons/jelly/JellyException.java
@@ -16,9 +16,6 @@
 
 package org.apache.commons.jelly;
 
-import java.io.PrintStream;
-import java.io.PrintWriter;
-
 /**
  * <p><code>JellyException</code> is the root of all Jelly exceptions.</p>
  *
@@ -143,45 +140,5 @@ public class JellyException extends Exception implements LocationAware {
 
     public String getReason() {
         return super.getMessage();
-    }
-
-    // #### overload the printStackTrace methods...
-    public void printStackTrace(PrintWriter s) {
-        synchronized (s) {
-            super.printStackTrace(s);
-            if  (getCause() != null && !isChainingSupported()) {
-                s.println("Root cause");
-                getCause().printStackTrace(s);
-            }
-        }
-    }
-
-    public void printStackTrace(PrintStream s) {
-        synchronized (s) {
-            super.printStackTrace(s);
-            if  (getCause() != null && !isChainingSupported()) {
-                s.println("Root cause");
-                getCause().printStackTrace(s);
-            }
-        }
-    }
-
-    public void printStackTrace() {
-        super.printStackTrace();
-        if (getCause() != null && !isChainingSupported()) {
-            System.out.println("Root cause");
-            getCause().printStackTrace();
-        }
-    }
-
-    private boolean isChainingSupported() {
-        try {
-            Throwable.class.getMethod("getCause", new Class[0]);
-            return true;
-        } catch (NoSuchMethodException e) {
-            return false;
-        } catch (SecurityException e) {
-            return false;
-        }
     }
 }

--- a/jelly-tags/xml/src/test/java/org/apache/commons/jelly/tags/xml/TestXMLTags.java
+++ b/jelly-tags/xml/src/test/java/org/apache/commons/jelly/tags/xml/TestXMLTags.java
@@ -43,6 +43,11 @@ import org.dom4j.DocumentHelper;
 import org.dom4j.Node;
 import org.dom4j.io.SAXContentHandler;
 import org.dom4j.io.XMLWriter;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Tests the parser, the engine and the XML tags
   *
@@ -110,7 +115,7 @@ public class TestXMLTags extends TestCase {
             evaluteScriptAsText(testBaseDir + "/elementWithNameSpaceError.jelly");
             Assert.fail("We should have bailed out with an JellyException");
         } catch (JellyException jex) {
-            assertTrue(jex.getReason().startsWith("Cannot set same prefix to diferent URI in same node"));
+            assertThat(jex.getReason(), startsWith("org.xml.sax.SAXException: Cannot set same prefix to diferent URI in same node"));
         }
     }
 
@@ -159,7 +164,7 @@ public class TestXMLTags extends TestCase {
             evaluteScriptAsText(testBaseDir + "/attributeNameSpaceDuplicatedNS.jelly");
             Assert.fail("We should have bailed out with an JellyException");
         } catch (JellyException jex) {
-            assertTrue(jex.getReason().startsWith("Cannot set same prefix to diferent URI in same node"));
+            assertTrue(jex.getReason().startsWith("org.xml.sax.SAXException: Cannot set same prefix to diferent URI in same node"));
         }
     }
 

--- a/jelly-tags/xml/src/test/java/org/apache/commons/jelly/tags/xml/TestXMLTags.java
+++ b/jelly-tags/xml/src/test/java/org/apache/commons/jelly/tags/xml/TestXMLTags.java
@@ -164,7 +164,7 @@ public class TestXMLTags extends TestCase {
             evaluteScriptAsText(testBaseDir + "/attributeNameSpaceDuplicatedNS.jelly");
             Assert.fail("We should have bailed out with an JellyException");
         } catch (JellyException jex) {
-            assertTrue(jex.getReason().startsWith("org.xml.sax.SAXException: Cannot set same prefix to diferent URI in same node"));
+            assertThat(jex.getReason(), startsWith("org.xml.sax.SAXException: Cannot set same prefix to diferent URI in same node"));
         }
     }
 


### PR DESCRIPTION
See [JENKINS-73774](https://issues.jenkins.io/browse/JENKINS-73774) for motivation in Jenkins.

### Testing done

Broke a Jelly file in Jenkins, and looked at the resulting output provided by `Functions#printThrowable`.

#### Before

<details><summary>Long screenshot with stack trace whose entire first half is useless</summary>

![Screenshot](https://github.com/user-attachments/assets/fd33e57e-f233-441d-93cd-95bff5886eed)

</details>

#### After

<details><summary>Much shorter screenshot with stack trace that starts with the relevant information</summary>

![Screenshot](https://github.com/user-attachments/assets/295691ec-0806-4e5c-8b2d-2fde91147188)


</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
