### PR TITLE
Stop managing JUnit Jupiter version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,6 @@
         <version>2.0.0</version>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>5.11.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
         <version>${ant.version}</version>


### PR DESCRIPTION
This is already managed by the parent POM.