### PR TITLE
[JENKINS-75568] Upgrade Jelly from EE 9 to EE 10

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,13 +44,13 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>5.0.0</version>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-      <version>2.0.0</version>
+      <version>3.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Context

Part of the following series of PRs:

- https://github.com/jenkinsci/stapler/pull/617
- https://github.com/jenkinsci/winstone/pull/422
- https://github.com/jenkinsci/jenkins/pull/10461
- https://github.com/jenkinsci/jenkins-test-harness/pull/941

### Description

Upgrade Jelly from EE 9 to EE 10 by bumping the version numbers of the relevant libraries to match those used by Jetty 12 (EE 10). This PR is ready for review and ready for merge from a Jenkins perspective, but it is not yet ready for merge from a CloudBees CI perspective (hence the "on hold" label).

### Testing done

See https://github.com/jenkinsci/jenkins/pull/10461.