### PR TITLE
Deploy `org.jenkins-ci:commons-jelly-tags-fmt` to Artifactory

### DIFF
--- a/jelly-tags/fmt/pom.xml
+++ b/jelly-tags/fmt/pom.xml
@@ -26,16 +26,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Jenkins core still consumes an old version from 2005, but we don't have any changes in our fork, so it should be safe to upgrade to the version from our fork, and this makes it possible for us to change this code in the future if (for some reason) we ever need to.