### PR TITLE
Update jaxen 2.0.0 to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   </distributionManagement>
 
   <properties>
-    <revision>1.1-jenkins-20250732</revision>
+    <revision>1.1-jenkins-20260418</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/jelly</gitHubRepo>
     <ant.version>1.10.17</ant.version>


### PR DESCRIPTION
## Update jaxen 2.0.0 to 2.0.1

Refer to the changelog at:

* https://github.com/jaxen-xpath/jaxen/releases/tag/v2.0.1

Once it is merged and released, then the new release of Jelly needs to be included in Stapler and a new Stapler release needs to be created.

Proposed for inclusion in Jenkins core with pull request:

* https://github.com/jenkinsci/jenkins/pull/26666

### Testing done

* Tests pass locally
* Create an incremental build of Stapler that uses the incremental build from this change
* Include that incremental build in a Jenkins core incremental build
* Test the Jenkins core incremental build in the plugin BOM
* Test the Jenkins core incremental build in the acceptance test harness

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
